### PR TITLE
workaround, using header

### DIFF
--- a/lib/tests.ts
+++ b/lib/tests.ts
@@ -1,6 +1,5 @@
 import Parser from 'fast-xml-parser';
 import db from '../models';
-import fs from 'fs';
 
 interface JunitTestcase {
   '@_classname': string;
@@ -78,8 +77,7 @@ export const storeBuildInfo = async (build: BuildInfo) => {
   });
 };
 
-export const storeTestData = async (filePath: string) => {
-  const rawContent = fs.readFileSync(filePath, { encoding: 'utf-8' });
+export const storeTestData = async (rawContent: string) => {
   const content = Parser.parse(rawContent, { ignoreAttributes: false });
   const { testsuites } = formatJunitContent(content);
 

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-console */
 const fs = require('fs');
 const commander = require('commander');
-const fetch = require('node-fetch');
-const FormData = require('form-data');
+const bent = require('bent');
 
 commander.option('-t, --token <token>', 'Api token: TODO');
 commander.option(
@@ -18,21 +17,21 @@ const getBuildInfo = () => {
   // CircleCI
   if (process.env.CIRCLECI === 'true') {
     return {
-      repositoryUrl: process.env.CIRCLE_REPOSITORY_URL,
-      branch: process.env.CIRCLE_BRANCH,
-      commitHash: process.env.CIRCLE_SHA1,
-      tag: process.env.CIRCLE_TAG,
-      pullRequestUrl: process.env.CIRCLE_PULL_REQUEST, // TODO: might be better to accept multiple urls, process.env.CIRCLE_PULL_REQUESTS.split(','),
-      buildUrl: process.env.CIRCLE_BUILD_URL,
+      'x-repository-url': process.env.CIRCLE_REPOSITORY_URL,
+      'x-branch': process.env.CIRCLE_BRANCH,
+      'x-commit-hash': process.env.CIRCLE_SHA1,
+      'x-tag': process.env.CIRCLE_TAG,
+      'x-pull-request-url': process.env.CIRCLE_PULL_REQUEST, // TODO: might be better to accept multiple urls, process.env.CIRCLE_PULL_REQUESTS.split(','),
+      'x-build-rl': process.env.CIRCLE_BUILD_URL,
     };
   } else if (process.env.MOCKCI === 'true') {
     return {
-      repositoryUrl: 'https://github.com/aha-oretama/testerve-ui',
-      branch: 'main',
-      commitHash: '3e39d5a0c3aa3bb6ffba1cbe8fde0858fe93b851',
-      tag: null,
-      pullRequestUrl: null,
-      buildUrl: 'https://circleci.com/gh/aha-oretama/reportstore-ui/22',
+      'x-repository-url': 'https://github.com/aha-oretama/testerve-ui',
+      'x-branch': 'main',
+      'x-commit-hash': '3e39d5a0c3aa3bb6ffba1cbe8fde0858fe93b851',
+      'x-tag': null,
+      'x-pull-request-url': null,
+      'x-build-rl': 'https://circleci.com/gh/aha-oretama/reportstore-ui/22',
     };
   }
 };
@@ -46,25 +45,23 @@ const testCommand = async () => {
     return 1;
   }
   try {
-    const form = new FormData();
-    const data = fs.createReadStream(filePath);
-    form.append('file', data);
-    const buildInfo = getBuildInfo();
-    Object.keys(buildInfo)
-      .filter((key) => !!buildInfo[key])
-      .forEach((key) => {
-        form.append(key, buildInfo[key]);
-      });
-
-    const response = await fetch(`${commander.url}api/tests`, {
-      method: 'POST',
-      body: form,
+    // TODO: Expected codes are https://github.com/aha-oretama/testerve-ui/blob/be29e03b9a89d7890822a6f319bdcf5874b9ba27/lib/upload.js#L49-L62
+    // However, Vercel is running in lambda in AWS.
+    // When posting FormData with file upload, server api always failed in parsing the body.
+    const data = fs.readFileSync(filePath);
+    const post = bent(commander.url, 'POST');
+    const response = await post('api/tests', data, {
+      'Content-Disposition': 'attachment; name="data"; filename="data"',
+      'Content-Type': 'image/jpeg',
+      'Content-Length': data.length,
+      ...getBuildInfo(),
     });
 
     if (response.status === 200) {
       console.log('Successfully uploaded!');
       return 0;
     } else {
+      console.log(`Response status is ${response.status}`, response);
       return 1;
     }
   } catch (e) {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -48,6 +48,7 @@ const testCommand = async () => {
     // TODO: Expected codes are https://github.com/aha-oretama/testerve-ui/blob/be29e03b9a89d7890822a6f319bdcf5874b9ba27/lib/upload.js#L49-L62
     // However, Vercel is running in lambda in AWS.
     // When posting FormData with file upload, server api always failed in parsing the body.
+    // Related discussion, https://github.com/vercel/next.js/discussions/11634#discussioncomment-143941
     const data = fs.readFileSync(filePath);
     const post = bent(commander.url, 'POST');
     const response = await post('api/tests', data, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2380,15 +2380,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/formidable": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.0.32.tgz",
-      "integrity": "sha512-jOAB5+GFW+C+2xdvUcpd/CnYg2rD5xCyagJLBJU+9PB4a/DKmsAqS9yZI3j/Q9zwvM7ztPHaAIH1ijzp4cezdQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -3145,7 +3136,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -3388,6 +3380,23 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bent": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/bent/-/bent-7.3.12.tgz",
+      "integrity": "sha512-T3yrKnVGB63zRuoco/7Ybl7BwwGZR0lceoVG5XmQyMIH9s19SV5m+a8qam4if0zQuAmOQTyPTPmsQBdAorGK3w==",
+      "requires": {
+        "bytesish": "^0.4.1",
+        "caseless": "~0.12.0",
+        "is-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -3577,6 +3586,11 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
+    "bytesish": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/bytesish/-/bytesish-0.4.4.tgz",
+      "integrity": "sha512-i4uu6M4zuMUiyfZN4RU2+i9+peJh//pXhd9x1oSe1LBkZ3LEbCoygu8W0bXTukU1Jme2txKuotpCZRaC3FLxcQ=="
+    },
     "cacache": {
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
@@ -3675,8 +3689,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -3984,6 +3997,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4574,7 +4588,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5943,21 +5958,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
-    },
-    "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -9273,12 +9273,14 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,13 +29,11 @@
     ]
   },
   "dependencies": {
+    "bent": "^7.3.12",
     "commander": "^6.2.1",
     "date-fns": "^2.16.1",
     "fast-xml-parser": "^3.17.6",
-    "form-data": "^3.0.0",
-    "formidable": "^1.2.2",
     "next": "^10.0.0",
-    "node-fetch": "^2.6.1",
     "pg": "^8.5.1",
     "pg-hstore": "^2.3.3",
     "react": "16.13.1",
@@ -47,7 +45,6 @@
     "@babel/preset-env": "^7.12.11",
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.2",
-    "@types/formidable": "^1.0.32",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.16",
     "@types/react": "^17.0.0",

--- a/pages/api/tests.ts
+++ b/pages/api/tests.ts
@@ -24,6 +24,7 @@ export default async (req: NextApiRequest, res: NextApiResponse<Response>) => {
     // Using headers is workaround
     // Vercel is running in lambda in AWS.
     // When posting FormData with file upload, server api always failed in parsing the body.
+    // Related discussion, https://github.com/vercel/next.js/discussions/11634#discussioncomment-143941
     const report = await storeTestData(req.body);
     await storeBuildInfo(getBuildInfo(report.id, req.headers));
     res.status(200).json({ result: 'uploaded' });

--- a/pages/api/tests.ts
+++ b/pages/api/tests.ts
@@ -1,62 +1,31 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Fields, Files, IncomingForm } from 'formidable';
 import { BuildInfo, storeBuildInfo, storeTestData } from '../../lib/tests';
+import { IncomingHttpHeaders } from 'http';
 
 interface Response {
   result: string;
 }
 
-// To parse form-data by formidable, https://stackoverflow.com/questions/60020241/next-js-file-upload-via-api-routes-formidable-not-working
-export const config = {
-  api: {
-    bodyParser: false,
-  },
-};
-
-interface ResolveData {
-  fields: Fields;
-  files: Files;
-}
-
-async function getBody(req: NextApiRequest): Promise<ResolveData> {
-  const form = new IncomingForm();
-  form.keepExtensions = true;
-  return await new Promise<ResolveData>((resolve, reject) => {
-    form.parse(req, (err, fields: Fields, files: Files) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve({
-        fields,
-        files,
-      });
-    });
-  });
-}
-
-const getBuildInfo = (reportId: number, fields: Fields) => {
+const getBuildInfo = (reportId: number, headers: IncomingHttpHeaders) => {
   return {
     reportId,
-    repositoryUrl: fields['repositoryUrl'],
-    branch: fields['branch'],
-    commitHash: fields['commitHash'],
-    tag: fields['tag'],
-    pullRequestUrl: fields['pullRequestUrl'],
-    buildUrl: fields['buildUrl'],
+    repositoryUrl: headers['x-repository-url'],
+    branch: headers['x-branch'],
+    commitHash: headers['x-commit-hash'],
+    tag: headers['x-tag'],
+    pullRequestUrl: headers['x-pull-request-url'],
+    buildUrl: headers['x-build-rl'],
   } as BuildInfo;
 };
 
 export default async (req: NextApiRequest, res: NextApiResponse<Response>) => {
   if (req.method === 'POST') {
-    const body = await getBody(req);
-
-    // files returns array when multiples is true, but never enable it
-    const path = Array.isArray(body.files.file)
-      ? body.files.file[0].path
-      : body.files.file.path;
-    const report = await storeTestData(path);
-    await storeBuildInfo(getBuildInfo(report.id, body.fields));
+    // TODO: Expected codes are https://github.com/aha-oretama/testerve-ui/blob/f64acb5219af0bba7e136ccd633917dc2139c504/pages/api/tests.ts#L10-L59
+    // Using headers is workaround
+    // Vercel is running in lambda in AWS.
+    // When posting FormData with file upload, server api always failed in parsing the body.
+    const report = await storeTestData(req.body);
+    await storeBuildInfo(getBuildInfo(report.id, req.headers));
     res.status(200).json({ result: 'uploaded' });
   } else {
     res.status(400).json({ result: 'not found' });

--- a/test/lib/tests.test.ts
+++ b/test/lib/tests.test.ts
@@ -6,14 +6,17 @@ import {
 } from '../../lib/tests';
 import path from 'path';
 import db from '../../models';
+import fs from 'fs';
 
 const dataDir = path.join(__dirname, '..', 'data');
 let report;
 let build;
 
 beforeAll(async () => {
+  const getFileContent = (fileName: string) =>
+    fs.readFileSync(path.join(dataDir, fileName), 'utf8');
   // To fix the order, don't use Promise.all
-  report = await storeTestData(path.join(dataDir, 'junit-pass.xml'));
+  report = await storeTestData(getFileContent('junit-pass.xml'));
   build = await storeBuildInfo({
     reportId: report.id,
     repositoryUrl: 'https://github.com/aha-oretama/testerve-ui',
@@ -21,8 +24,8 @@ beforeAll(async () => {
     commitHash: '3e39d5a0c3aa3bb6ffba1cbe8fde0858fe93b851',
     buildUrl: 'https://circleci.com/gh/aha-oretama/reportstore-ui/22',
   });
-  await storeTestData(path.join(dataDir, 'junit-fail.xml'));
-  await storeTestData(path.join(dataDir, 'junit-fail-skip.xml'));
+  await storeTestData(getFileContent('junit-fail.xml'));
+  await storeTestData(getFileContent('junit-fail-skip.xml'));
 });
 
 describe('Build', () => {


### PR DESCRIPTION
Vercel is running in lambda in AWS.
When posting FormData with file upload, server api always failed in parsing the body.
Related discussion, https://github.com/vercel/next.js/discussions/11634#discussioncomment-143941

Then, we use headers to pass build information, this is a workaround.